### PR TITLE
fix(pyproject): correct dev dependency name and add CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,14 @@ dependencies = [
     "setuptools>=80.8.0",
 ]
 
+[project.scripts]
+fletx = "fletx.__main__:main"
+
 [project.urls]
 "Homepage" = "https://github.com/AllDotPy/FletX"
 
 [project.optional-dependencies]
-dev = ["pytest", "black", "mypy","twine","uv","buil"]
+dev = ["pytest", "black", "mypy","twine","uv","build"]
 
 [tool.setuptools]
 packages = ["fletx"]


### PR DESCRIPTION
This PR fixes two issues in the `pyproject.toml` that prevent the CLI from working and break dependency resolution with `uv`.

---

## What was fixed

### 1. 🔧 Invalid dependency name

- Replaced `buil` (typo) with the correct `build` in `[project.optional-dependencies.dev]`.
- The typo caused the following error during installation:


### 2. 🚀 Missing CLI entry point

- Added the `[project.scripts]` section to register the `fletx` CLI command:

```toml
[project.scripts]
fletx = "fletx.__main__:main"
```

- This enables terminal execution like:

```
fletx new my_app --no-install
```

- Without this, users encounter:

```
error: Failed to spawn: `fletx`
Caused by: No such file or directory (os error 2)
```

### How to test

#### Here’s the exact procedure used to test this fix:

- #### Option 1: With pip only

1. cd /path/to/fletx

2. pip install -e .

3. fletx new my_app --no-install

✅ CLI should work as expected.

---

- #### Option 2: With uv


1. Run `uv build` in the root of the forked `FletX project`.

2. Created a new Python project elsewhere.

3. In that project’s `pyproject.toml`, added the dependency pointing to the local fork:

```
dependencies = [
    "fletx @ file:///path/to/your/local/fletx",
]
```
6. Run `uv sync` to install all dependencies (including the local `fletxr`).

7. Tested the CLI with:

```
uv run fletx new fletx_login_migration --no-install
```

✅ CLI should work as expected.

---

> Happy to update documentation, write tests, or adjust anything if requested.
> Thank you for the great project — excited to contribute!