### PR TITLE
Fix premature execution of `on_shutdown` hooks in FletXApp* (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ uv.lock
 dist/*
 docs/*
 build/*
+**/test_routing.py

--- a/examples/1/main.py
+++ b/examples/1/main.py
@@ -3,24 +3,15 @@ import flet as ft
 from fletx.app import FletXApp
 from routes import MyAppRouter
 
-def main():#(page: ft.Page):
-    # Configuration de la page
-    # page.title = "Mon App FletX"
+def main():
 
-    # # Setting up theme
-    # page.theme = ft.Theme(
-    #     color_scheme_seed = ft.Colors.GREEN
-    # )
-    # page.dark_theme = ft.Theme(
-    #     color_scheme_seed = ft.Colors.BLUE_800,
-    #     scaffold_bgcolor = ft.Colors.BLACK,
-    #     font_family = 'Bebas Neue, sans-serif',
-    # )
-    # page.theme_mode = ft.ThemeMode.DARK
-
-    # # Setting up window size
-    # page.window.height = 810
-    # page.window.width = 400
+    # Lifecycle Hooks 
+    async def on_startup(page: ft.Page):
+        print("App is running!")
+        page.padding = 0
+    
+    def on_shutdown(page: ft.Page):
+        print("App is closed!")
     
     # Initialisation de l'application FletX
     app = FletXApp(
@@ -34,7 +25,9 @@ def main():#(page: ft.Page):
             color_scheme_seed = ft.Colors.BLUE_800,
             scaffold_bgcolor = ft.Colors.BLACK,
             font_family = 'Bebas Neue, sans-serif',
-        )
+        ),
+        on_startup = on_startup,
+        on_shutdown = on_shutdown,
     ).with_window_size(400,810)
     
     # Cette méthode initialise le router avec la page Flet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "flet[all]>=0.28.3",
     "httpx>=0.28.1",
     "pydantic>=2.11.5",
+    "pytest>=8.4.0",
     "setuptools>=80.8.0",
     "uvloop>=0.21.0",
 ]

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -1,0 +1,110 @@
+import pytest
+from unittest.mock import patch, Mock
+from fletx.core.http import HTTPClient, HTTPResponse
+
+@pytest.fixture
+def client():
+    return HTTPClient(base_url="https://api.example.com", debug=True)
+
+def test_httpclient_initialization_defaults():
+    client = HTTPClient()
+    assert client.base_url == ""
+    assert client.timeout == 30
+    assert client.max_retries == 3
+    assert client.retry_delay == 1.0
+    assert client.debug is False
+    assert client.proxy is None
+    assert client.pool_size == 100
+    assert client.verify_ssl is True
+    assert client.follow_redirects is True
+    assert client.max_redirects == 10
+    assert client.default_cookies == {}
+    assert client.sync_mode is False
+    assert isinstance(client.default_headers, dict)
+    assert "User-Agent" in client.default_headers
+
+def test_httpclient_custom_initialization():
+    headers = {"X-Test": "yes"}
+    cookies = {"session": "abc"}
+    client = HTTPClient(
+        base_url="https://api.example.com/",
+        default_headers=headers,
+        timeout=10,
+        max_retries=5,
+        retry_delay=2.0,
+        debug=True,
+        proxy="http://localhost:8080",
+        pool_size=10,
+        verify_ssl=False,
+        follow_redirects=False,
+        max_redirects=5,
+        cookies=cookies,
+        sync_mode=True
+    )
+    assert client.base_url == "https://api.example.com"
+    assert client.default_headers["X-Test"] == "yes"
+    assert client.timeout == 10
+    assert client.max_retries == 5
+    assert client.retry_delay == 2.0
+    assert client.debug is True
+    assert client.proxy == "http://localhost:8080"
+    assert client.pool_size == 10
+    assert client.verify_ssl is False
+    assert client.follow_redirects is False
+    assert client.max_redirects == 5
+    assert client.default_cookies == cookies
+    assert client.sync_mode is True
+
+def test_add_middleware(client):
+    middleware = Mock()
+    client.add_middleware(middleware)
+    assert middleware in client.middlewares
+
+def test_set_auth(client):
+    client.set_auth("token123", auth_type="Bearer")
+    assert any(m.__class__.__name__ == "AuthMiddleware" for m in client.middlewares)
+
+def test_set_rate_limit(client):
+    client.set_rate_limit(5.0)
+    assert client.rate_limit_per_second == 5.0
+
+def test_set_progress_callbacks(client):
+    upload_cb = Mock()
+    download_cb = Mock()
+    client.set_upload_progress_callback(upload_cb)
+    client.set_download_progress_callback(download_cb)
+    assert client.upload_progress_callback is upload_cb
+    assert client.download_progress_callback is download_cb
+
+def test_sync_request(monkeypatch, client):
+    # Patch the _request_sync method to return a fake response
+    fake_response = HTTPResponse(
+        status=200,
+        headers={"Content-Type": "application/json"},
+        data={"ok": True},
+        elapsed=0.1,
+        url="https://api.example.com/test"
+    )
+    monkeypatch.setattr(client, "_request_sync", lambda *a, **k: fake_response)
+    resp = client.request("GET", "/test", sync=True)
+    assert isinstance(resp, HTTPResponse)
+    assert resp.status == 200
+    assert resp.ok
+    assert resp.is_json
+    assert resp.json() == {"ok": True}
+
+def test_get_post_patch_delete_methods(monkeypatch, client):
+    fake_response = HTTPResponse(
+        status=201,
+        headers={},
+        data="created",
+        elapsed=0.05,
+        url="https://api.example.com/resource"
+    )
+    monkeypatch.setattr(client, "_request_sync", lambda *a, **k: fake_response)
+    assert client.get("/resource", sync=True).status == 201
+    assert client.post("/resource", sync=True).status == 201
+    assert client.patch("/resource", sync=True).status == 201
+    assert client.delete("/resource", sync=True).status == 201
+    assert client.put("/resource", sync=True).status == 201
+


### PR DESCRIPTION
* Fletx.cli: update controller template; fletx.core.decorators: Enable Reactive Forms to call form errorscallback in realtime; Update readme and Contrution guide.

* Feat/add unit tests http (#43)

* test: add init defaults test

* test: custom init

* test: auth, rate limit, middleware

* test: all client requests

* Fix: FletXApp calls on_shutdown hooks just after initialization. #38

---------