### PR TITLE
Fix on_shutdown hook Runtime warnning and allow Navigation mode definition in FletXApp instance.

### DIFF
--- a/fletx/core/routing/router.py
+++ b/fletx/core/routing/router.py
@@ -133,6 +133,11 @@ class FletXRouter:
         if self.state.navigation_mode in [NavigationMode.VIEWS, NavigationMode.HYBRID]:
             self.logger.debug("Flet view popped")
             self.go_back()
+
+    def set_navigation_mode(self, mode: NavigationMode):
+        """Set Router Navigation mode"""
+
+        self.state.navigation_mode = mode
     
     # @worker_task
     async def navigate(


### PR DESCRIPTION
This PR fixes the #82 issues and adds navigation mode setting via FletXApp (#80 issues)

**Example usage**
```python
from fletx.navigation import NavigationMode

# App Configuration
    app = FletXApp(
        title="Fakeshop",
        initial_route = "/",
        navigation_mode = NavigationMode.HYBRID,     # VIEWS by default
        debug = True,
        theme = light_theme,
        dark_theme = dark_theme,
        window_config = {
            "width": 400,
            "height": 810,
            "resizable": True,
            "maximizable": True
        },
        on_startup = on_startup,
        on_shutdown = on_shutdown
    )
```