### PR TITLE
FletX.Core.Page: add Bottom_Sheet utilities to the FletX Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 tree.txt
 uv.lock
 **/*_builder.py
+**/stepper.py
 **/*nfc.py
 dist/*
 build/*

--- a/fletx/core/page.py
+++ b/fletx/core/page.py
@@ -234,6 +234,18 @@ class FletXPage(ft.Container, ABC):
 
         return None
     
+    def build_bottom_sheet(
+        self, 
+        *args, 
+        **extra_kwargs
+    ) -> ft.BottomSheet:
+        """
+        Builds bottom sheet.
+        Override this method to use a custom bottom sheet.
+        """
+
+        return ft.BottomSheet()
+    
     def build_navigation_widgets(self):
         """Build all needed Navigation widgets."""
 
@@ -264,9 +276,6 @@ class FletXPage(ft.Container, ABC):
 
         self.logger.debug(f"Page {self.__class__.__name__} will mount")
         self._state = PageState.ACTIVE
-
-        # Build Navigation widgets
-        self.build_navigation_widgets()
 
         # Call On init hook
         self.on_init()
@@ -608,6 +617,21 @@ class FletXPage(ft.Container, ABC):
         page = self.page_instance
         if page and self.view.end_drawer:
             page.close(self.view.end_drawer)
+
+    def open_bottom_sheet(
+        self, content: ft.Control, 
+        on_dismiss: Optional[Callable[[],]] = None
+    ):
+        """Shows a given content in a bottom sheet"""
+
+        # First get the bottom sheet widget to use
+        bts = self.build_bottom_sheet()
+
+        # Set content 
+        bts.content = content
+        bts.on_dismiss = on_dismiss
+
+        self.page_instance.open(bts)
     
     def refresh(self):
         """Refresh the page"""
@@ -721,7 +745,11 @@ class FletXPage(ft.Container, ABC):
 
         try:
             start_time = datetime.now()
+            # Build Page Content
             content = self.build()
+
+            # Then Navigation widgets
+            self.build_navigation_widgets()
             end_time = datetime.now()
             
             # Measure build time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [{ name = "#Einswilli", email = "einswilligoeh@email.com" }]
 requires-python = "==3.12"
 keywords = [
     "fletx", "fletxr", "flet", "reactive state",
-    "routing", "di", "dependency ijection"
+    "routing", "di", "dependency injection"
 ]
 dependencies = [
     "aiohttp>=3.9.5",


### PR DESCRIPTION
This PR Adds Bottom_Sheet utilities to the FletX Page.

**Usage**
```python
class HomePage(FletXPage:
    ...
    def do_stuff(self):
        self.open_bottom_sheet(content = Text('Hello from Bottom sheet')).   # <-- Here
    ...
```