### PR TITLE
Flix: `TypeError: Callable must be used as Callable[[arg, ...], result]` Error in FletXPage (#94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 tree.txt
 uv.lock
 **/*_builder.py
+**/stepper.py
 **/*nfc.py
 dist/*
 build/*

--- a/fletx/cli/__init__.py
+++ b/fletx/cli/__init__.py
@@ -89,7 +89,7 @@ class FletXCLI:
                 return
             
             elif command_name in ['-v', '--version', 'version']:
-                self.print_vertion()
+                self.print_version()
                 return
             
             # Get and execute the command
@@ -181,7 +181,7 @@ class FletXCLI:
         print("  fletx <command> --help")
         print("  fletx help <command>")
 
-    def print_vertion(self):
+    def print_version(self):
         """Print current fletx version"""
         from fletx import __version__
 

--- a/fletx/core/page.py
+++ b/fletx/core/page.py
@@ -632,6 +632,19 @@ class FletXPage(ft.Container, ABC):
         bts.on_dismiss = on_dismiss
 
         self.page_instance.open(bts)
+
+    def show_loader(
+        self, 
+        content: Optional[ft.Control] = None, 
+        on_dismiss: Optional[Callable[[ft.ControlEvent]]] = None
+    ):
+        """Show a given content in a dialog"""
+
+        dialog = ft.AlertDialog(
+            content = content if content else ft.ProgressRing(),
+            on_dismiss = on_dismiss
+        )
+        self.page_instance.open(dialog)
     
     def refresh(self):
         """Refresh the page"""

--- a/fletx/core/page.py
+++ b/fletx/core/page.py
@@ -234,6 +234,18 @@ class FletXPage(ft.Container, ABC):
 
         return None
     
+    def build_bottom_sheet(
+        self, 
+        *args, 
+        **extra_kwargs
+    ) -> ft.BottomSheet:
+        """
+        Builds bottom sheet.
+        Override this method to use a custom bottom sheet.
+        """
+
+        return ft.BottomSheet()
+    
     def build_navigation_widgets(self):
         """Build all needed Navigation widgets."""
 
@@ -264,9 +276,6 @@ class FletXPage(ft.Container, ABC):
 
         self.logger.debug(f"Page {self.__class__.__name__} will mount")
         self._state = PageState.ACTIVE
-
-        # Build Navigation widgets
-        self.build_navigation_widgets()
 
         # Call On init hook
         self.on_init()
@@ -608,6 +617,21 @@ class FletXPage(ft.Container, ABC):
         page = self.page_instance
         if page and self.view.end_drawer:
             page.close(self.view.end_drawer)
+
+    def open_bottom_sheet(
+        self, content: ft.Control, 
+        on_dismiss: Optional[Callable[[],]] = None
+    ):
+        """Shows a given content in a bottom sheet"""
+
+        # First get the bottom sheet widget to use
+        bts = self.build_bottom_sheet()
+
+        # Set content 
+        bts.content = content
+        bts.on_dismiss = on_dismiss
+
+        self.page_instance.open(bts)
     
     def refresh(self):
         """Refresh the page"""
@@ -721,7 +745,11 @@ class FletXPage(ft.Container, ABC):
 
         try:
             start_time = datetime.now()
+            # Build Page Content
             content = self.build()
+
+            # Then Navigation widgets
+            self.build_navigation_widgets()
             end_time = datetime.now()
             
             # Measure build time

--- a/fletx/core/page.py
+++ b/fletx/core/page.py
@@ -638,7 +638,7 @@ class FletXPage(ft.Container, ABC):
         content: Optional[ft.Control] = None, 
         on_dismiss: Optional[Callable[[ft.ControlEvent]]] = None
     ):
-        """Show a given content in a dialog"""
+        """Show a given content in a ft.AlertDialog"""
 
         dialog = ft.AlertDialog(
             content = content if content else ft.ProgressRing(),

--- a/fletx/core/page.py
+++ b/fletx/core/page.py
@@ -620,7 +620,7 @@ class FletXPage(ft.Container, ABC):
 
     def open_bottom_sheet(
         self, content: ft.Control, 
-        on_dismiss: Optional[Callable[[],]] = None
+        on_dismiss: Optional[Callable[[ft.ControlEvent], Any]] = None
     ):
         """Shows a given content in a bottom sheet"""
 
@@ -636,7 +636,7 @@ class FletXPage(ft.Container, ABC):
     def show_loader(
         self, 
         content: Optional[ft.Control] = None, 
-        on_dismiss: Optional[Callable[[ft.ControlEvent]]] = None
+        on_dismiss: Optional[Callable[[ft.ControlEvent], Any]] = None
     ):
         """Show a given content in a ft.AlertDialog"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [{ name = "#Einswilli", email = "einswilligoeh@email.com" }]
 requires-python = "==3.12"
 keywords = [
     "fletx", "fletxr", "flet", "reactive state",
-    "routing", "di", "dependency ijection"
+    "routing", "di", "dependency injection"
 ]
 dependencies = [
     "aiohttp>=3.9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "FletXr"
-version = "0.1.4.b1"
+version = "0.1.4.b2"
 description = "The GetX-inspired Python Framework for Building Reactive, Cross-Platform Apps with Flet"
 readme = "PYPI.md"
 license = {file = "LICENSE"}

--- a/setup_.py
+++ b/setup_.py
@@ -6,7 +6,7 @@ with open("PYPI.md", "r", encoding="utf-8") as fh:
 
 setup(
     name = 'FletXr',
-    version = '0.1.4.b1',
+    version = '0.1.4.b2',
     packages = find_packages(),
     install_requires = [
         "aiohttp>=3.12.13",


### PR DESCRIPTION
This PR fixes the `TypeError: Callable must be used as Callable[[arg, ...], result]` Error in FletXPage (issue #94)