### PR TITLE
feat(docs): overhaul FletX docs with progressive Architecture guide, 

### DIFF
--- a/docs/assets/diagrams/di.svg
+++ b/docs/assets/diagrams/di.svg
@@ -29,3 +29,4 @@
   <line x1="630" y1="100" x2="630" y2="130" stroke="#2563EB" stroke-width="3" marker-end="url(#arrow)"/>
 </svg>
 
+

--- a/docs/assets/diagrams/di.svg
+++ b/docs/assets/diagrams/di.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="220" viewBox="0 0 760 220">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#2563EB" />
+    </marker>
+    <style>
+      .box{fill:#ffffff;stroke:#1f2937;stroke-width:2;rx:8;ry:8}
+      .label{font-family:Inter,Arial,sans-serif;font-size:14px;fill:#111827}
+      .title{font-family:Inter,Arial,sans-serif;font-size:16px;font-weight:700;fill:#111827}
+    </style>
+  </defs>
+  <rect x="40" y="40" width="220" height="60" class="box"/>
+  <text x="150" y="65" text-anchor="middle" class="title">Controller</text>
+  <text x="150" y="85" text-anchor="middle" class="label">asks for dependency</text>
+
+  <rect x="300" y="40" width="200" height="60" class="box"/>
+  <text x="400" y="65" text-anchor="middle" class="title">DI Container</text>
+  <text x="400" y="85" text-anchor="middle" class="label">resolves/creates</text>
+
+  <rect x="540" y="40" width="180" height="60" class="box"/>
+  <text x="630" y="65" text-anchor="middle" class="title">Service</text>
+  <text x="630" y="85" text-anchor="middle" class="label">e.g., UserService</text>
+
+  <rect x="300" y="130" width="420" height="60" class="box"/>
+  <text x="510" y="165" text-anchor="middle" class="title">Controller uses Service</text>
+
+  <line x1="260" y1="70" x2="300" y2="70" stroke="#2563EB" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="500" y1="70" x2="540" y2="70" stroke="#2563EB" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="630" y1="100" x2="630" y2="130" stroke="#2563EB" stroke-width="3" marker-end="url(#arrow)"/>
+</svg>
+

--- a/docs/assets/diagrams/reactivity.svg
+++ b/docs/assets/diagrams/reactivity.svg
@@ -30,3 +30,4 @@
   <line x1="640" y1="90" x2="640" y2="120" stroke="#4F46E5" stroke-width="3" marker-end="url(#arrow)"/>
 </svg>
 
+

--- a/docs/assets/diagrams/reactivity.svg
+++ b/docs/assets/diagrams/reactivity.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="200" viewBox="0 0 760 200">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#4F46E5" />
+    </marker>
+    <style>
+      .box{fill:#ffffff;stroke:#1f2937;stroke-width:2;rx:8;ry:8}
+      .label{font-family:Inter,Arial,sans-serif;font-size:14px;fill:#111827}
+      .title{font-family:Inter,Arial,sans-serif;font-size:16px;font-weight:700;fill:#111827}
+    </style>
+  </defs>
+  <rect x="20" y="30" width="190" height="60" class="box"/>
+  <text x="115" y="55" text-anchor="middle" class="title">Widget event</text>
+  <text x="115" y="75" text-anchor="middle" class="label">e.g., on_click()</text>
+
+  <rect x="280" y="30" width="200" height="60" class="box"/>
+  <text x="380" y="55" text-anchor="middle" class="title">Controller method</text>
+  <text x="380" y="75" text-anchor="middle" class="label">updates Rx value</text>
+
+  <rect x="540" y="30" width="200" height="60" class="box"/>
+  <text x="640" y="55" text-anchor="middle" class="title">Reactive state (Rx*)</text>
+  <text x="640" y="75" text-anchor="middle" class="label">change detected</text>
+
+  <rect x="280" y="120" width="200" height="60" class="box"/>
+  <text x="380" y="145" text-anchor="middle" class="title">Widgets re-render</text>
+  <text x="380" y="165" text-anchor="middle" class="label">bound via lambda/decorators</text>
+
+  <line x1="210" y1="60" x2="280" y2="60" stroke="#4F46E5" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="480" y1="60" x2="540" y2="60" stroke="#4F46E5" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="640" y1="90" x2="640" y2="120" stroke="#4F46E5" stroke-width="3" marker-end="url(#arrow)"/>
+</svg>
+

--- a/docs/assets/diagrams/routing.svg
+++ b/docs/assets/diagrams/routing.svg
@@ -34,3 +34,4 @@
   <line x1="715" y1="90" x2="715" y2="120" stroke="#059669" stroke-width="3" marker-end="url(#arrow)"/>
 </svg>
 
+

--- a/docs/assets/diagrams/routing.svg
+++ b/docs/assets/diagrams/routing.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="220" viewBox="0 0 820 220">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#059669" />
+    </marker>
+    <style>
+      .box{fill:#ffffff;stroke:#1f2937;stroke-width:2;rx:8;ry:8}
+      .label{font-family:Inter,Arial,sans-serif;font-size:14px;fill:#111827}
+      .title{font-family:Inter,Arial,sans-serif;font-size:16px;font-weight:700;fill:#111827}
+    </style>
+  </defs>
+  <rect x="20" y="30" width="170" height="60" class="box"/>
+  <text x="105" y="55" text-anchor="middle" class="title">URL change</text>
+  <text x="105" y="75" text-anchor="middle" class="label">/user/42</text>
+
+  <rect x="230" y="30" width="180" height="60" class="box"/>
+  <text x="320" y="55" text-anchor="middle" class="title">Router</text>
+  <text x="320" y="75" text-anchor="middle" class="label">matches route</text>
+
+  <rect x="440" y="30" width="170" height="60" class="box"/>
+  <text x="525" y="55" text-anchor="middle" class="title">Create Page</text>
+  <text x="525" y="75" text-anchor="middle" class="label">UserPage</text>
+
+  <rect x="630" y="30" width="170" height="60" class="box"/>
+  <text x="715" y="55" text-anchor="middle" class="title">Attach Controller</text>
+  <text x="715" y="75" text-anchor="middle" class="label">UserController</text>
+
+  <rect x="230" y="120" width="570" height="60" class="box"/>
+  <text x="515" y="155" text-anchor="middle" class="title">build() → UI</text>
+
+  <line x1="190" y1="60" x2="230" y2="60" stroke="#059669" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="410" y1="60" x2="440" y2="60" stroke="#059669" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="610" y1="60" x2="630" y2="60" stroke="#059669" stroke-width="3" marker-end="url(#arrow)"/>
+  <line x1="715" y1="90" x2="715" y2="120" stroke="#059669" stroke-width="3" marker-end="url(#arrow)"/>
+</svg>
+

--- a/docs/getting-started/routing.md
+++ b/docs/getting-started/routing.md
@@ -6,6 +6,14 @@ FletX also provides utility functions for programmatic navigation, such as `navi
 
 ---
 
+!!! tip "How to read routing diagrams"
+
+    - Boxes represent **router steps** or **components**.
+    - Arrows indicate **navigation flow** (URL → match → page → controller → UI).
+    - Prefer using the Architecture guide’s diagrams as a quick mental model.
+
+[← Back to Architecture](architecture.md)
+
 ## 🧭 Basic Routing
 
 Use the global `router_config` to define your app's navigation structure:
@@ -268,5 +276,5 @@ go_back()
 ## 🧠 Next Steps
 
 * Dive into [dependency injection](dependency-injection.md)
-* Explore the [sevices](services.md)
+* Explore the [services](services.md)
 * Learn about the [Architecture](architecture.md)

--- a/docs/getting-started/state-management.md
+++ b/docs/getting-started/state-management.md
@@ -4,6 +4,16 @@
 
 ---
 
+!!! tip "How to read reactivity diagrams"
+
+    - Boxes are **state holders** (Rx) or **consumers** (widgets/controllers).
+
+    - Arrows show **state change propagation**.
+
+    - Use the Architecture guide’s reactivity figure as a companion visual.
+
+[← Back to Architecture](architecture.md)
+
 ### 🔄 Why reactivity matters
 
 In most frameworks, when a value changes (e.g. a user logs in), you need to manually update the UI, synchronize the state, or refresh components.


### PR DESCRIPTION
This PR makes the Architecture docs easier to learn and more practical. It rewrites the guide from a high-level overview down to details, adds simple SVG diagrams (reactivity, routing, DI) with clear captions/alt text, and includes small examples showing how Pages and Controllers interact and how state updates propagate. It also adds tip callouts for reading the diagrams, “Back to Architecture” links in related pages, and fixes a small typo in Routing. The goal is faster onboarding and clearer mental models for how FletX pieces fit together. No code changes or breaking changes docs only.

![di](https://github.com/user-attachments/assets/777a6cbb-8d0b-409e-9df8-e81d50a78a7b)
![reactivity](https://github.com/user-attachments/assets/38c2bf64-ee38-4ea5-95c3-70a55abac240)
![routing](https://github.com/user-attachments/assets/f9920aa2-b841-4b63-9248-000c448e7be7)
