### PR TITLE
Update router.py for guard async compatibility

### DIFF
--- a/fletx/core/routing/router.py
+++ b/fletx/core/routing/router.py
@@ -371,7 +371,7 @@ class FletXRouter:
             if not await guard.can_activate(route_info):
                 redirect_path = await guard.redirect_to(route_info)
                 if redirect_path:
-                    self.navigate(redirect_path, replace=True)
+                    await self.navigate(redirect_path, replace=True)
                     return NavigationResult.REDIRECTED
                 return NavigationResult.BLOCKED_BY_GUARD
         


### PR DESCRIPTION
Use `await self.navigate` for guard route redirection for  `_check_activation_guards` method. Without this, guard breaks in async version of the app.